### PR TITLE
补充宁波话字词

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 |suzhou|苏州话|8615 characters and 11617 words|
 |wuxi|无锡话|5047 characters and 8466 words|
 |hangzhou|杭州话|4450 characters and 10838 words|
-|ningbo|宁波话|1083 characters and 10021 words|
+|ningbo|宁波话|17595 characters and 106836 words|
 |yixing|宜兴话|5358 characters and 2404 words|
 |xiashi|硖石话|283 characters and 2144 words|
 |wenzhou|温州话|5345 characters|


### PR DESCRIPTION
补充宁波话字词。

来自：

- [甬江話字詞表](https://github.com/ionkaon/dictionary)
- [寧波話吳語拼音輸入方案](https://github.com/NGLI/rime-wugniu_gninpou)
- [寧波話【八股文】](https://github.com/ionkaon/gninpou-essay)

多音字及多音词保留了最常见的读音。字同时收录繁简，词语使用 OpenCC 进行了繁简转换，同时收录了繁简写法。

有几个字用了 IDC，如 `⿱咋會	ʣɐɪ˨˦`，这类需要保留还是去掉？